### PR TITLE
Revert "feat(container): update ghcr.io/siderolabs/kubelet ( v1.30.3 → v1.31.0 )"

### DIFF
--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
@@ -50,4 +50,4 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
       TALOS_VERSION: v1.7.6
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-      KUBERNETES_VERSION: v1.31.0
+      KUBERNETES_VERSION: v1.30.3


### PR DESCRIPTION
Revert because current version of Talos (1.7.X) does not support Kubernetes v1.31.0