### PR TITLE
feat(default): add TREK travel planner

### DIFF
--- a/kubernetes/apps/default/trek/app/externalsecret.yaml
+++ b/kubernetes/apps/default/trek/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name trek-secret
+  namespace: default
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secrets-manager
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      data:
+        ENCRYPTION_KEY: "{{ .encryption_key }}"
+  dataFrom:
+    - extract:
+        key: *name

--- a/kubernetes/apps/default/trek/app/helmrelease.yaml
+++ b/kubernetes/apps/default/trek/app/helmrelease.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trek
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: trek
+      version: 3.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: trek
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    image:
+      repository: mauriceboe/trek
+      tag: 3.1.2
+    service:
+      type: ClusterIP
+      port: 3000
+    env:
+      NODE_ENV: production
+      PORT: 3000
+      TZ: America/Chicago
+      APP_URL: https://trek.ewatkins.dev
+      ALLOWED_ORIGINS: https://trek.ewatkins.dev
+      FORCE_HTTPS: "false"
+      TRUST_PROXY: "1"
+    existingSecret: trek-secret
+    existingSecretKey: ENCRYPTION_KEY
+    persistence:
+      enabled: true
+      data:
+        size: 2Gi
+        storageClassName: nfs-slow
+      uploads:
+        size: 5Gi
+        storageClassName: nfs-slow
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    ingress:
+      enabled: false

--- a/kubernetes/apps/default/trek/app/httproute.yaml
+++ b/kubernetes/apps/default/trek/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: trek
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "internal.ewatkins.dev"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "trek.ewatkins.dev"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Strict-Transport-Security
+                value: "max-age=31449600; includeSubDomains"
+      backendRefs:
+        - name: trek
+          port: 3000

--- a/kubernetes/apps/default/trek/app/kustomization.yaml
+++ b/kubernetes/apps/default/trek/app/kustomization.yaml
@@ -3,8 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Pre Flux-Kustomizations
-  - ./namespace.yaml
-  # Flux-Kustomizations
-  - ./outline/ks.yaml
-  - ./trek/ks.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/default/trek/ks.yaml
+++ b/kubernetes/apps/default/trek/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app trek
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/trek/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: talos-cluster
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - ./postfinance.yaml
   - ./runix.yaml
   - ./stakater.yaml
+  - ./trek.yaml

--- a/kubernetes/flux/repositories/helm/trek.yaml
+++ b/kubernetes/flux/repositories/helm/trek.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: trek
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://mauriceboe.github.io/TREK


### PR DESCRIPTION
## Summary
Deploys [TREK](https://github.com/mauriceboe/TREK), a self-hosted collaborative travel planner, into the `default` namespace via its official Helm chart.

## Changes
- Add `trek` `HelmRepository` (`https://mauriceboe.github.io/TREK`)
- `HelmRelease` for chart `trek` v3.1.2 (image `mauriceboe/trek:3.1.2`)
  - `nfs-slow` PVCs: data 2Gi, uploads 5Gi
  - Chart ingress disabled in favor of a Gateway API `HTTPRoute`
- `HTTPRoute` for `trek.ewatkins.dev` on the internal gateway
- `ExternalSecret` pulling `ENCRYPTION_KEY` from Bitwarden into `trek-secret`

## Notes
- Requires a Bitwarden secrets-manager item `trek-secret` with field `encryption_key` (done).