### PR TITLE
feat(network): migrate external-dns-unifi-webhook to home-operations

### DIFF
--- a/kubernetes/apps/network/unifi-dns/README.md
+++ b/kubernetes/apps/network/unifi-dns/README.md
@@ -7,7 +7,7 @@ ExternalDNS configured with the UniFi webhook provider. It watches Gateway API H
 | Setting | Value | Notes |
 | --- | --- | --- |
 | Chart | `external-dns` `1.20.0` | OCI mirror at `ghcr.io/home-operations/charts-mirror/external-dns`, verified with cosign |
-| Provider | `webhook` | Uses `ghcr.io/kashalls/external-dns-unifi-webhook:v0.8.2` as a sidecar |
+| Provider | `webhook` | Uses `ghcr.io/home-operations/external-dns-unifi-webhook:0.10.6` as a sidecar |
 | UniFi controller | `https://10.0.0.1` | |
 | Sources | `gateway-httproute`, `service` | Publishes records for Gateway API HTTPRoutes and LoadBalancer Services |
 | Domain filter | `ewatkins.dev` | Scoped to this zone; records outside it are ignored |
@@ -24,4 +24,4 @@ ExternalDNS configured with the UniFi webhook provider. It watches Gateway API H
 
 - [ExternalDNS Documentation](https://kubernetes-sigs.github.io/external-dns/)
 - [GitHub Repository](https://github.com/kubernetes-sigs/external-dns)
-- [UniFi Webhook Repository](https://github.com/kashalls/external-dns-unifi-webhook)
+- [UniFi Webhook Repository](https://github.com/home-operations/external-dns-unifi-webhook)

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -44,8 +44,8 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.8.2@sha256:7f0ddbbc83a36a2a9d762e25eef9cafcb3adf0493068a27d72ae71087eafe6f0
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.6@sha256:b35a7aac743ddbf7edff3266d8b0b0ac108dc0d56d692b322e51ec99f57b34c5
         env:
           - name: UNIFI_HOST
             value: "https://10.0.0.1"


### PR DESCRIPTION
## Summary

The `external-dns-unifi-webhook` project was adopted by [home-operations](https://github.com/home-operations) from `kashalls`. This migrates the sidecar image accordingly.

- Repository: `ghcr.io/kashalls/external-dns-unifi-webhook` → `ghcr.io/home-operations/external-dns-unifi-webhook`
- Tag: `v0.8.2` → `0.10.6` (the new repo drops the `v` prefix on tags), pinned to digest `sha256:b35a7aac…`
- Updated the app README references

## Validation

Rendered offline with [`flate`](https://github.com/home-operations/flate); the `unifi-dns` HelmRelease inflates cleanly with the new image. The `0.10.6` release reverts the brief move of the metrics/health server to port 8081, so the existing `http-webhook` probes remain correct.