### PR TITLE
fix(network): use duration units for unifi-dns webhook timeouts

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -57,9 +57,9 @@ spec:
           - name: LOG_LEVEL
             value: *logLevel
           - name: SERVER_READ_TIMEOUT
-            value: "300"
+            value: "300s"
           - name: SERVER_WRITE_TIMEOUT
-            value: "300"
+            value: "300s"
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

Hotfix for a regression from #1765 (kashalls → home-operations webhook migration).

The new `ghcr.io/home-operations/external-dns-unifi-webhook:0.10.6` parses `SERVER_READ_TIMEOUT` / `SERVER_WRITE_TIMEOUT` as Go `time.Duration`, so the bare `"300"` values crash the webhook on startup:

```
parse error on field "ServerReadTimeout" of type "time.Duration":
  unable to parse duration: time: missing unit in duration "300"
```

The old kashalls webhook accepted bare seconds; the new one requires a unit. Changed both to `"300s"` (same 300s intent).

## Impact

The crashing webhook left the `unifi-dns` Deployment unavailable, putting its HelmRelease into a perpetual upgrade→timeout→rollback loop. This restores it.