### PR TITLE
fix(database): grant dragonfly-operator configmaps RBAC

### DIFF
--- a/kubernetes/apps/database/dragonfly/operator/rbac.yaml
+++ b/kubernetes/apps/database/dragonfly/operator/rbac.yaml
@@ -11,7 +11,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "services"]
+    resources: ["configmaps", "pods", "services"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]


### PR DESCRIPTION
## Summary

The dragonfly-operator bump to v1.6.1 (#1752/#1753) added a ConfigMap controller. The operator now lists/watches ConfigMaps on startup, but the local `rbac.yaml` ClusterRole didn't grant it, so it crashes:

```
configmaps is forbidden: User "system:serviceaccount:database:dragonfly-operator"
  cannot list resource "configmaps" ... ERROR setup problem running manager:
  failed to wait for DragonflyPodLifecycle caches to sync ... *v1.Pod: timed out
```

Renovate bumped the image/CRDs but couldn't update the hand-maintained RBAC. Added `configmaps` to the existing core-resource rule, matching upstream v1.6.1's ClusterRole (configmaps share the same verbs as pods/services).