### PR TITLE
fix(database): bump crunchy-postgres image to pgBackRest 2.58.0 (match repo-host)

### DIFF
--- a/kubernetes/apps/database/crunchy-postgres-operator/cluster/cluster.yaml
+++ b/kubernetes/apps/database/crunchy-postgres-operator/cluster/cluster.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       crunchy-userinit.ramblurr.github.com/enabled: "true"
       crunchy-userinit.ramblurr.github.com/superuser: &superuser "postgres"
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.11-2550
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.14-2621
   postgresVersion: 16
 
   monitoring:


### PR DESCRIPTION
## Summary

The PGO 6.0.2 upgrade (#1755) bumped the **repo-host** to pgBackRest **2.58.0**, but the Postgres **instance** image was pinned to `ubi9-16.11-2550` (pgBackRest **2.56.0**). pgBackRest requires matching versions on local + remote, so repo1's host-to-host protocol handshake failed:

```
repo1: error (other)
  [ProtocolError] expected value '2.56.0' for greeting key 'version' but got '2.58.0'
```

This failed all repo1 backups and left **WAL segments stuck unarchived** (disk-fill risk; repo2/repo3 on object storage kept working since they don't do the host handshake).

## Fix

Bump the instance image to `ubi9-16.14-2621` — PGO 6.0.2's matching default for Postgres 16 (`RELATED_IMAGE_POSTGRES_16`), which ships pgBackRest 2.58.0 (same build `2621` as the repo-host). Also moves Postgres 16.11 → 16.14 (patch).

## Impact

PGO performs a rolling restart of the instances (replicas first, primary last with failover). After it completes, pgBackRest versions align and archiving/backups recover.

## Note

The **vector** cluster has the same skew but its third-party `vectorchord` image has no 2.58.0 build yet (latest ships 2.54.2); that needs a separate repo-host pin and is intentionally not addressed here.