### PR TITLE
feat(app): add homarr dashboard to default namespace

### DIFF
--- a/kubernetes/apps/default/homarr/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homarr/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homarr-db-secret
+  namespace: default
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secrets-manager
+  target:
+    name: homarr-db-secret
+    template:
+      engineVersion: v2
+      data:
+        db-encryption-key: "{{ .db_encryption_key }}"
+  dataFrom:
+    - extract:
+        key: homarr-secret

--- a/kubernetes/apps/default/homarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homarr/app/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homarr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: homarr
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    env:
+      TZ: ${TIMEZONE}
+    envSecrets:
+      dbCredentials:
+        existingSecret: homarr-db-secret
+    persistence:
+      homarrDatabase:
+        enabled: true
+        storageClassName: ""
+        size: 500Mi
+    ingress:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/default/homarr/app/httproute.yaml
+++ b/kubernetes/apps/default/homarr/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homarr
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "internal.ewatkins.dev"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "homarr.ewatkins.dev"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Strict-Transport-Security
+                value: "max-age=31449600; includeSubDomains"
+      backendRefs:
+        - name: homarr
+          port: 7575

--- a/kubernetes/apps/default/homarr/app/httproute.yaml
+++ b/kubernetes/apps/default/homarr/app/httproute.yaml
@@ -13,6 +13,7 @@ spec:
       sectionName: https
   hostnames:
     - "homarr.ewatkins.dev"
+    - "home.ewatkins.dev"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/default/homarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/homarr/app/kustomization.yaml
@@ -3,9 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Pre Flux-Kustomizations
-  - ./namespace.yaml
-  # Flux-Kustomizations
-  - ./homarr/ks.yaml
-  - ./outline/ks.yaml
-  - ./trek/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/homarr/ks.yaml
+++ b/kubernetes/apps/default/homarr/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app homarr
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/homarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: talos-cluster
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/flux/repositories/oci/homarr.yaml
+++ b/kubernetes/flux/repositories/oci/homarr.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: homarr
+  namespace: flux-system
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 8.20.0
+  url: oci://ghcr.io/homarr-labs/charts/homarr

--- a/kubernetes/flux/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/repositories/oci/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./forgejo.yaml
   - ./prometheus-community.yaml
   - ./spegel.yaml
+  - ./homarr.yaml
   - ./stevehipwell.yaml


### PR DESCRIPTION
## Summary

- Deploys Homarr (v1.68.0) as a home dashboard using its official Helm chart (8.20.0) via OCI
- Configures a 500Mi PVC for the SQLite database
- Exposes the app via HTTPRoute at `homarr.ewatkins.dev`
- Secret encryption key is sourced from Bitwarden via ExternalSecrets

## Test plan

- [ ] Flux reconciles `homarr` Kustomization without errors
- [ ] `homarr-db-secret` ExternalSecret syncs from Bitwarden (create a secret named `homarr-secret` with key `db_encryption_key`)
- [ ] Homarr pod reaches `Running` state in the `default` namespace
- [ ] `https://homarr.ewatkins.dev` is reachable and loads the dashboard