### PR TITLE
fix(observability): guard Prometheus against runaway WAL / DiskPressure

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/README.md
+++ b/kubernetes/apps/observability/kube-prometheus-stack/README.md
@@ -27,9 +27,16 @@ This cluster uses `fullNameOverride: kps` with `cleanPrometheusOperatorObjectNam
 | Setting | Value | Notes |
 | --- | --- | --- |
 | Local retention | 2 days | Short-lived; long-term storage handled by Thanos |
-| Local storage limit | 8 GiB | WAL compression enabled |
+| Local block size limit | 15 GiB | `retentionSize`; bounds persisted blocks only, **not** the WAL |
+| PVC size | 25 GiB | Headroom so WAL spikes don't drive the node into `DiskPressure` |
+| Memory | 1 Gi request / 2 Gi limit | Reserved to avoid OOM/evict crash-loops during WAL replay |
 | Remote storage | Thanos sidecar | Uploads blocks to Minio via S3 |
 | Replica label | `__replica__` | Used for Thanos deduplication |
+
+> **Note:** `openebs-hostpath` PVs share the node's `/var` filesystem and are not
+> quota-enforced, so the PVC size is nominal. The real guard against a runaway WAL
+> filling the node is keeping Prometheus from crash-looping (adequate memory) plus
+> the retention settings above. See [Runaway WAL](#runaway-wal--diskpressure-evictions).
 
 Prometheus runs with a Thanos sidecar that exposes a gRPC store endpoint and uploads compacted blocks to the `thanos` Minio bucket. The Thanos query layer then federates across this sidecar and the store gateway to provide the full historical view.
 
@@ -60,6 +67,30 @@ Several high-cardinality label sets are dropped at scrape time to keep storage m
 ### High Memory / OOMKilled
 
 - [Identifying metrics driving high cardinality](https://www.robustperception.io/which-are-my-biggest-metrics)
+
+### Runaway WAL / DiskPressure evictions
+
+If a node hosting `prometheus-kps-0` starts evicting pods with
+`The node had condition: [DiskPressure]`, the TSDB write-ahead log has likely
+ballooned and filled the node's `/var` filesystem. This happens when Prometheus
+crash-loops (OOM/evicted) and never survives long enough to compact the head into
+a block and truncate the WAL — a self-sustaining loop, since the pod is pinned to
+the node by its local PV.
+
+Diagnose (michigan = `10.40.1.3`):
+
+```sh
+talosctl -n <node-ip> usage -H -d 2 /var/openebs/local/<pvc-id>/prometheus-db   # is `wal` huge?
+kubectl get node <node> -o jsonpath='{.spec.taints}'                            # disk-pressure taint?
+```
+
+Recover (resets local TSDB only; long-term data is safe in Thanos):
+
+```sh
+kubectl -n observability patch prometheus kps --type merge -p '{"spec":{"replicas":0}}'
+kubectl -n observability delete pvc prometheus-kps-db-prometheus-kps-0   # reclaim=Delete frees the dir
+kubectl -n observability patch prometheus kps --type merge -p '{"spec":{"replicas":1}}'
+```
 
 ### Deleting a Stuck Metric Series
 

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -158,21 +158,33 @@ spec:
               name: thanos-objstore-config
               key: config
         retention: 2d
-        retentionSize: 8GiB
+        # Keep the on-disk block size well under the PVC request. retentionSize
+        # only bounds persisted blocks, not the WAL, so leave generous headroom.
+        retentionSize: 15GiB
         externalLabels:
           cluster: talos-cluster
         resources:
           requests:
             cpu: 100m
+            # Reserve memory so the scheduler accounts for WAL replay, which is
+            # memory-hungry. Missing requests let the pod get OOM/evicted and
+            # crash-loop before it can compact + truncate the WAL.
+            memory: 1Gi
+            ephemeral-storage: 1Gi
           limits:
-            memory: 1500Mi
+            # Headroom above the request so WAL replay on restart does not OOM.
+            memory: 2Gi
+            ephemeral-storage: 2Gi
         storageSpec:
           volumeClaimTemplate:
             spec:
               storageClassName: openebs-hostpath
               resources:
                 requests:
-                  storage: 10Gi
+                  # openebs-hostpath shares the node filesystem and does not hard
+                  # enforce this, but the larger request gives the WAL room to
+                  # spike without driving the node into DiskPressure eviction.
+                  storage: 25Gi
 
         podAntiAffinity: soft
         podAntiAffinityTopologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## What happened

`prometheus-kps-0`'s TSDB write-ahead log ballooned to **~80 GiB** and filled michigan's `/var` filesystem (106 GB total → 85% used, ~16 GB free). That dropped free space below kubelet's default `nodefs.available < 15%` hard-eviction threshold, so michigan kept flapping `DiskPressure` and evicting pods (`promtail`, `garage-2`, and Prometheus itself).

It was a self-sustaining loop: the evicted pods used almost no disk, so evicting them freed nothing, and Prometheus is pinned to michigan by its local hostPath PV — so it rescheduled there and got evicted again before it could compact the head into a block and truncate the WAL. `openebs-hostpath` doesn't enforce the PVC size, and `retentionSize` only bounds persisted blocks (not the WAL), so nothing capped the growth.

The live incident was already remediated (scaled Prometheus to 0, deleted the bloated PVC to reclaim the 80 GB, scaled back to 1 on a fresh volume). This PR hardens the config so it doesn't recur.

## Changes

- **Memory guard (primary fix):** add a `memory` request (`1Gi`, previously none) and raise the limit `1500Mi → 2Gi`. A pod with a limit but no request is prone to OOM/eviction during memory-hungry WAL replay — exactly the crash-loop that let the WAL grow unbounded.
- **Ephemeral-storage guard:** add `ephemeral-storage` request/limit (`1Gi`/`2Gi`) as defense-in-depth for container/log/emptyDir writes.
- **Disk sizing:** bump the PVC request `10Gi → 25Gi` for WAL headroom and raise `retentionSize 8GiB → 15GiB` (still comfortably under the PVC).
- **Docs:** document the failure mode + recovery runbook in the README and correct the config table.

## Caveats / follow-ups

`openebs-hostpath` PVs share the node's `/var` and are **not** quota-enforced, so the PVC size is nominal — the memory guard is what actually breaks the crash-loop. Still worth doing separately:
- Expand michigan's `/var` (Proxmox VM disk) — 106 GB is tight.
- Consider moving Prometheus to a quota-enforcing storage class.

## Validation

`task kubernetes:validate` passes (HelmRelease `kube-prometheus-stack` is valid).