### PR TITLE
fix: guard nodes against disk exhaustion (kubelet image GC + emptyDir cap)

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -181,6 +181,9 @@ spec:
                 subPath: dotCache
       tmpfs:
         type: emptyDir
+        # Disk-backed emptyDir (geocoding dump + transformers cache); cap it so
+        # runaway growth evicts this pod instead of draining the node.
+        sizeLimit: 10Gi
         advancedMounts:
           immich:
             main:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -31,6 +31,12 @@ patches:
               - rw
         extraArgs:
           rotate-server-certificates: "true"
+        extraConfig:
+          # Prune unused images well before the ~85% DiskPressure eviction
+          # threshold; the kubelet default (85/80) races eviction. huron hit
+          # 75% with 530 cached images before this was added.
+          imageGCHighThresholdPercent: 70
+          imageGCLowThresholdPercent: 60
       nodeLabels:
         topology.kubernetes.io/zone: homelab
 nodes:


### PR DESCRIPTION
## Problem

Reviewing node disk headroom after the michigan DiskPressure incident (#1823), **huron is at 75% `/var` usage** — and 57 GB of it is containerd image cache: **530 cached images** vs 62–326 on peer nodes, accumulated from months of Renovate image bumps.

Root cause: kubelet's default image GC thresholds (`imageGCHighThresholdPercent: 85`, low: 80) only start pruning at the same disk level where DiskPressure eviction begins (`nodefs.available < 15%`). GC and eviction race each other — by design the node only cleans up when it's already nearly in trouble. Every node drifts toward this; huron is just furthest along.

## Changes

- **talos/talconfig.yaml** — set kubelet `imageGCHighThresholdPercent: 70` / `imageGCLowThresholdPercent: 60` in the shared machine patch (all nodes). Unused images now get pruned at 70% disk, down to 60% — well clear of eviction territory. huron should drop from 75% → ~60% shortly after the config applies.
- **immich** — cap the disk-backed `tmpfs` emptyDir (reverse-geocoding dump + transformers cache) at `sizeLimit: 10Gi`, so runaway growth evicts the immich pod rather than draining the node. (Investigated the ML pod's apparent 10.5 GB usage first — it turned out to be `du` traversing the NFS library mount plus its cache PVC, both bounded/non-local; the server pod's emptyDir is the actual unbounded volume.)

## Rollout

- immich: applies via Flux on merge (pod restart).
- kubelet GC: Flux does not manage Talos config — requires `talhelper genconfig` + `talosctl apply-config` per node. Kubelet restarts in place; no reboot, pods unaffected.

## Validation

`task kubernetes:validate` passes.