### PR TITLE
fix(pulse): raise gateway request timeout for Patrol model preflight

### DIFF
--- a/kubernetes/apps/observability/pulse/app/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/observability/pulse/app/backendtrafficpolicy.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: pulse-timeout
+  namespace: observability
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: pulse
+  timeout:
+    http:
+      requestTimeout: "300s"

--- a/kubernetes/apps/observability/pulse/app/kustomization.yaml
+++ b/kubernetes/apps/observability/pulse/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./externalsecret.yaml
   - ./pvc.yaml
   - ./httproute.yaml
+  - ./backendtrafficpolicy.yaml


### PR DESCRIPTION
## Problem

Pulse's Patrol "Check Patrol model" preflight fails with **upstream request timeout** (Envoy's 504 body), which the UI misreports as the backend being unreachable.

The preflight runs real inference against Ollama on the Jetson. A cold load of `qwen2.5-coder:7b` (4.7 GB) measures at ~70s, well past the Envoy Gateway default 15s route timeout — the pulse HTTPRoute had no override.

## Fix

Add a `BackendTrafficPolicy` targeting the `pulse` HTTPRoute with `requestTimeout: 300s`, mirroring the existing `open-webui-timeout` policy that solved the same problem for open-webui on the same internal gateway. Uses `targetRefs` (plural) to avoid the deprecation warning the open-webui policy reports.

## Verification

- `kubectl kustomize` renders the policy correctly
- `task kubernetes:validate` (kubeconform) passes
- Cold-load timing measured directly against `jetson.ewatkins.dev:11434`: load 67.9s, total 69.0s